### PR TITLE
feat: add keyboard shortcuts entry to overflow menus

### DIFF
--- a/crates/core/src/queries.rs
+++ b/crates/core/src/queries.rs
@@ -134,6 +134,48 @@ pub async fn list_items(
     })
 }
 
+/// Count dismissed items grouped by (project_id, item_type).
+pub async fn count_dismissed_grouped(
+    db: &DatabaseConnection,
+) -> Result<Vec<DismissedCount>, sea_orm::DbErr> {
+    use sea_orm::FromQueryResult;
+
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        project_id: String,
+        item_type: String,
+        count: i64,
+    }
+
+    let rows = item::Entity::find()
+        .filter(item::Column::ItemStatus.eq(ItemStatus::Dismissed))
+        .select_only()
+        .column(item::Column::ProjectId)
+        .column(item::Column::ItemType)
+        .column_as(item::Column::Id.count(), "count")
+        .group_by(item::Column::ProjectId)
+        .group_by(item::Column::ItemType)
+        .into_model::<Row>()
+        .all(db)
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| DismissedCount {
+            project_id: r.project_id,
+            item_type: r.item_type,
+            count: r.count as u64,
+        })
+        .collect())
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DismissedCount {
+    pub project_id: String,
+    pub item_type: String,
+    pub count: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -732,5 +774,91 @@ mod tests {
 
         assert_eq!(result.items.len(), 1);
         assert_eq!(result.items[0].title, "Dismissed");
+    }
+
+    #[tokio::test]
+    async fn count_dismissed_grouped_by_project_and_type() {
+        let db = setup_test_db().await;
+        let connector = ConnectorFactory::default().create(&db).await;
+        let project_a = ProjectFactory::default()
+            .name("project-a")
+            .connector_id(&connector.id)
+            .create(&db)
+            .await;
+        let project_b = ProjectFactory::default()
+            .name("project-b")
+            .connector_id(&connector.id)
+            .create(&db)
+            .await;
+
+        // Project A: 2 dismissed issues, 1 dismissed PR, 1 pending
+        ItemFactory::new(&project_a.id, 1)
+            .item_type(ItemType::Issue)
+            .item_status(ItemStatus::Dismissed)
+            .dismissed_at(now())
+            .create(&db)
+            .await;
+        ItemFactory::new(&project_a.id, 2)
+            .item_type(ItemType::Issue)
+            .item_status(ItemStatus::Dismissed)
+            .dismissed_at(now())
+            .create(&db)
+            .await;
+        ItemFactory::new(&project_a.id, 3)
+            .item_type(ItemType::PullRequest)
+            .item_status(ItemStatus::Dismissed)
+            .dismissed_at(now())
+            .create(&db)
+            .await;
+        ItemFactory::new(&project_a.id, 4)
+            .item_type(ItemType::Issue)
+            .create(&db)
+            .await;
+
+        // Project B: 1 dismissed issue
+        ItemFactory::new(&project_b.id, 5)
+            .item_type(ItemType::Issue)
+            .item_status(ItemStatus::Dismissed)
+            .dismissed_at(now())
+            .create(&db)
+            .await;
+
+        let counts = count_dismissed_grouped(&db).await.unwrap();
+
+        // Should have 3 groups: (A, issue), (A, pr), (B, issue)
+        assert_eq!(counts.len(), 3);
+
+        let a_issues: u64 = counts
+            .iter()
+            .filter(|c| c.project_id == project_a.id && c.item_type == "issue")
+            .map(|c| c.count)
+            .sum();
+        assert_eq!(a_issues, 2);
+
+        let a_prs: u64 = counts
+            .iter()
+            .filter(|c| c.project_id == project_a.id && c.item_type == "pr")
+            .map(|c| c.count)
+            .sum();
+        assert_eq!(a_prs, 1);
+
+        let b_issues: u64 = counts
+            .iter()
+            .filter(|c| c.project_id == project_b.id && c.item_type == "issue")
+            .map(|c| c.count)
+            .sum();
+        assert_eq!(b_issues, 1);
+    }
+
+    #[tokio::test]
+    async fn count_dismissed_grouped_empty_when_none_dismissed() {
+        let (db, project) = setup().await;
+        ItemFactory::new(&project.id, 1)
+            .title("Pending item")
+            .create(&db)
+            .await;
+
+        let counts = count_dismissed_grouped(&db).await.unwrap();
+        assert!(counts.is_empty());
     }
 }

--- a/src-tauri/src/commands/items.rs
+++ b/src-tauri/src/commands/items.rs
@@ -80,6 +80,7 @@ pub struct ItemPageResponse {
     pub items: Vec<ItemResponse>,
     pub next_cursor: Option<String>,
     pub has_more: bool,
+    pub dismissed_counts: Vec<ossue_core::queries::DismissedCount>,
 }
 
 #[tauri::command]
@@ -95,30 +96,45 @@ pub async fn list_items(
     tracing::debug!(project_id = ?project_id, item_type = ?item_type, search_query = ?search_query, cursor = ?cursor, "Listing items");
     let db = state.get_db().await?;
 
-    let page = ossue_core::queries::list_items(
-        &db,
-        ossue_core::queries::ListItemsParams {
-            project_id,
-            item_type,
-            starred_only: starred_only.unwrap_or(false),
-            search_query,
-            cursor,
-            page_size: page_size.unwrap_or(50),
-            dismissed: false,
+    let (page, dismissed_counts) = tokio::try_join!(
+        async {
+            ossue_core::queries::list_items(
+                &db,
+                ossue_core::queries::ListItemsParams {
+                    project_id,
+                    item_type,
+                    starred_only: starred_only.unwrap_or(false),
+                    search_query,
+                    cursor,
+                    page_size: page_size.unwrap_or(50),
+                    dismissed: false,
+                },
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "Failed to query items from database");
+                CommandError::Internal {
+                    message: e.to_string(),
+                }
+            })
         },
-    )
-    .await
-    .map_err(|e| {
-        tracing::error!(error = %e, "Failed to query items from database");
-        CommandError::Internal {
-            message: e.to_string(),
+        async {
+            ossue_core::queries::count_dismissed_grouped(&db)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "Failed to count dismissed items");
+                    CommandError::Internal {
+                        message: e.to_string(),
+                    }
+                })
         }
-    })?;
+    )?;
 
     Ok(ItemPageResponse {
         items: page.items.into_iter().map(ItemResponse::from).collect(),
         next_cursor: page.next_cursor,
         has_more: page.has_more,
+        dismissed_counts,
     })
 }
 
@@ -273,30 +289,45 @@ pub async fn list_dismissed_items(
     tracing::debug!(project_id = ?project_id, item_type = ?item_type, search_query = ?search_query, cursor = ?cursor, "Listing dismissed items");
     let db = state.get_db().await?;
 
-    let page = ossue_core::queries::list_items(
-        &db,
-        ossue_core::queries::ListItemsParams {
-            project_id,
-            item_type,
-            starred_only: false,
-            search_query,
-            cursor,
-            page_size: page_size.unwrap_or(50),
-            dismissed: true,
+    let (page, dismissed_counts) = tokio::try_join!(
+        async {
+            ossue_core::queries::list_items(
+                &db,
+                ossue_core::queries::ListItemsParams {
+                    project_id,
+                    item_type,
+                    starred_only: false,
+                    search_query,
+                    cursor,
+                    page_size: page_size.unwrap_or(50),
+                    dismissed: true,
+                },
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "Failed to query dismissed items from database");
+                CommandError::Internal {
+                    message: e.to_string(),
+                }
+            })
         },
-    )
-    .await
-    .map_err(|e| {
-        tracing::error!(error = %e, "Failed to query dismissed items from database");
-        CommandError::Internal {
-            message: e.to_string(),
+        async {
+            ossue_core::queries::count_dismissed_grouped(&db)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "Failed to count dismissed items");
+                    CommandError::Internal {
+                        message: e.to_string(),
+                    }
+                })
         }
-    })?;
+    )?;
 
     Ok(ItemPageResponse {
         items: page.items.into_iter().map(ItemResponse::from).collect(),
         next_cursor: page.next_cursor,
         has_more: page.has_more,
+        dismissed_counts,
     })
 }
 

--- a/src/components/inbox/InboxItem.tsx
+++ b/src/components/inbox/InboxItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, forwardRef } from "react";
 import type { Item } from "@/types";
 import { formatTimeAgo } from "@/lib/utils";
 import { getLabelColor } from "@/lib/labels";
@@ -53,7 +53,8 @@ interface InboxItemProps {
   isAnalyzing?: boolean;
   hasAnalysis?: boolean;
   isChecked: boolean;
-  onToggleSelect: () => void;
+  isFocused?: boolean;
+  onToggleSelect: (e: React.MouseEvent) => void;
   onClick: () => void;
   onToggleStar: () => void;
   onMarkUnread: () => void;
@@ -62,7 +63,7 @@ interface InboxItemProps {
   isDismissedView?: boolean;
 }
 
-export function InboxItem({ item, repoName, platform, isSelected, isAnalyzing, hasAnalysis, isChecked, onToggleSelect, onClick, onToggleStar, onMarkUnread, onDelete, onRestore, isDismissedView }: InboxItemProps) {
+export const InboxItem = forwardRef<HTMLElement, InboxItemProps>(function InboxItem({ item, repoName, platform, isSelected, isAnalyzing, hasAnalysis, isChecked, isFocused, onToggleSelect, onClick, onToggleStar, onMarkUnread, onDelete, onRestore, isDismissedView }, ref) {
   const [bodyExpanded, setBodyExpanded] = useState(false);
   const timeAgo = formatTimeAgo(item.updated_at);
   const strippedBody = item.body ? stripMarkdown(item.body) : "";
@@ -71,8 +72,9 @@ export function InboxItem({ item, repoName, platform, isSelected, isAnalyzing, h
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <button
-          className={`block w-full border-b px-4 py-3.5 text-left transition-colors hover:bg-muted/50 ${
-            isSelected ? "bg-muted border-l-2 border-l-primary" : ""
+          ref={ref as React.Ref<HTMLButtonElement>}
+          className={`block w-full border-l-2 border-b px-4 py-3.5 text-left transition-colors hover:bg-muted/50 ${
+            isSelected ? "bg-muted border-l-primary" : isFocused ? "border-l-primary/30" : "border-l-transparent"
           } ${item.is_read && !isSelected ? "text-foreground/70" : ""}`}
           onClick={onClick}
         >
@@ -81,7 +83,7 @@ export function InboxItem({ item, repoName, platform, isSelected, isAnalyzing, h
               checked={isChecked}
               onClick={(e) => {
                 e.stopPropagation();
-                onToggleSelect();
+                onToggleSelect(e as unknown as React.MouseEvent);
               }}
               className="shrink-0"
             />
@@ -200,5 +202,5 @@ export function InboxItem({ item, repoName, platform, isSelected, isAnalyzing, h
       </ContextMenuContent>
     </ContextMenu>
   );
-}
+});
 

--- a/src/components/layout/InboxList.tsx
+++ b/src/components/layout/InboxList.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useEffect, useCallback, useState } from "react";
 import { errorMessage } from "@/lib/utils";
 import { useItems } from "@/hooks/useItems";
 import { useAppStore } from "@/stores/appStore";
+import { useItemStore } from "@/stores/itemStore";
 import { useDraftIssueStore } from "@/stores/draftIssueStore";
 import { InboxItem } from "@/components/inbox/InboxItem";
 import { NoteItem } from "@/components/notes/NoteItem";
@@ -11,9 +12,10 @@ import { CreateNoteDialog } from "@/components/notes/CreateNoteDialog";
 import { SyncProgressBar } from "@/components/inbox/SyncProgressBar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   MoreVertical, RefreshCw, RotateCw, RotateCcw, Loader2, Plus, StickyNote, Search, X,
-  Star, EyeOff, Sparkles, PauseCircle, Inbox, SearchX, CircleDot, GitPullRequest, MessageCircle,
+  Star, EyeOff, Sparkles, PauseCircle, Inbox, SearchX, CircleDot, GitPullRequest, MessageCircle, Keyboard,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
@@ -21,27 +23,38 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { toast } from "sonner";
 import * as api from "@/lib/tauri";
 import type { AnalysisAction } from "@/types";
 import { EmptyState } from "@/components/shared/EmptyState";
+import { KeyboardShortcutsDialog } from "@/components/shared/KeyboardShortcutsDialog";
 
 export function InboxList() {
   const { items, syncItems, isSyncing, syncDisabled, setSelectedItemId, selectedItemId, markRead, markUnread, deleteItem, restoreItem, fullSync } = useItems();
-  const { selectedProjectIds, projects, syncingProjects, activeAnalyses, selectedItemIds, toggleItemSelection, clearSelection, startAnalysis, clearAnalysis, analyzedItemIds, showAnalyzedOnly, showStarredOnly, showDismissedOnly, updateItem, itemTypeFilter, refreshInbox, hasMore, isLoadingMore, fetchMore, searchQuery, setSearchQuery } = useAppStore();
+  const { selectedProjectIds, projects, syncingProjects, activeAnalyses, selectedItemIds, toggleItemSelection, selectAllItems, clearSelection, startAnalysis, clearAnalysis, analyzedItemIds, showAnalyzedOnly, showStarredOnly, showDismissedOnly, updateItem, itemTypeFilter, refreshInbox, hasMore, isLoadingMore, fetchMore, searchQuery, setSearchQuery } = useAppStore();
   const {
     selectedNoteId,
     setSelectedNoteId,
     selectedNoteIds,
     toggleNoteSelection,
     clearNoteSelection,
+    lastClickedNoteIndex,
+    setLastClickedNoteIndex,
     isGenerating,
     setIsGenerating,
     openCreateNote,
     openEditNote,
   } = useDraftIssueStore();
+  const {
+    lastClickedIndex,
+    setLastClickedIndex,
+    focusedIndex,
+    setFocusedIndex,
+  } = useItemStore();
 
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [localSearch, setLocalSearch] = useState(searchQuery);
   const [isSearchOpen, setIsSearchOpen] = useState(searchQuery.length > 0);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -120,6 +133,72 @@ export function InboxList() {
     () => filteredItems.filter((i) => i.item_type === "note" && selectedNoteIdSet.has(i.id)),
     [filteredItems, selectedNoteIdSet]
   );
+
+  // Range selection handler for shift+click
+  const handleToggleSelectItem = useCallback(
+    (id: string, index: number, event: React.MouseEvent) => {
+      if (event.shiftKey && lastClickedIndex !== null) {
+        const start = Math.min(lastClickedIndex, index);
+        const end = Math.max(lastClickedIndex, index);
+        const rangeIds = filteredItems
+          .slice(start, end + 1)
+          .filter((item) => item.item_type !== "note")
+          .map((item) => item.id);
+        const merged = new Set([...selectedItemIds, ...rangeIds]);
+        selectAllItems(Array.from(merged));
+      } else {
+        toggleItemSelection(id);
+      }
+      setLastClickedIndex(index);
+    },
+    [lastClickedIndex, filteredItems, selectedItemIds, selectAllItems, toggleItemSelection, setLastClickedIndex]
+  );
+
+  const handleToggleSelectNote = useCallback(
+    (id: string, index: number, event: React.MouseEvent) => {
+      if (event.shiftKey && lastClickedNoteIndex !== null) {
+        const start = Math.min(lastClickedNoteIndex, index);
+        const end = Math.max(lastClickedNoteIndex, index);
+        const rangeIds = filteredItems
+          .slice(start, end + 1)
+          .filter((item) => item.item_type === "note")
+          .map((item) => item.id);
+        const merged = new Set([...selectedNoteIds, ...rangeIds]);
+        useDraftIssueStore.setState({ selectedNoteIds: Array.from(merged) });
+      } else {
+        toggleNoteSelection(id);
+      }
+      setLastClickedNoteIndex(index);
+    },
+    [lastClickedNoteIndex, filteredItems, selectedNoteIds, toggleNoteSelection, setLastClickedNoteIndex]
+  );
+
+  // Select All checkbox logic
+  const nonNoteItems = useMemo(
+    () => filteredItems.filter((item) => item.item_type !== "note"),
+    [filteredItems]
+  );
+  const noteItems = useMemo(
+    () => filteredItems.filter((item) => item.item_type === "note"),
+    [filteredItems]
+  );
+  const allItemsSelected = nonNoteItems.length > 0 && nonNoteItems.every((item) => selectedIdSet.has(item.id));
+  const allNotesSelected = noteItems.length > 0 && noteItems.every((item) => selectedNoteIdSet.has(item.id));
+  const someSelected = selectedItemIds.length > 0 || selectedNoteIds.length > 0;
+  const allSelected = (nonNoteItems.length === 0 || allItemsSelected) && (noteItems.length === 0 || allNotesSelected) && filteredItems.length > 0;
+
+  const handleSelectAll = useCallback(() => {
+    if (allSelected) {
+      clearSelection();
+      clearNoteSelection();
+    } else {
+      if (nonNoteItems.length > 0) selectAllItems(nonNoteItems.map((i) => i.id));
+      if (noteItems.length > 0) useDraftIssueStore.setState({ selectedNoteIds: noteItems.map((i) => i.id) });
+    }
+  }, [allSelected, nonNoteItems, noteItems, selectAllItems, clearSelection, clearNoteSelection]);
+
+  // Keyboard navigation
+  const itemRefs = useRef<Map<number, HTMLElement>>(new Map());
 
   const handleItemClick = async (id: string) => {
     setSelectedNoteId(null);
@@ -204,6 +283,110 @@ export function InboxList() {
     clearSelection();
     setSelectedNoteId(id);
   };
+
+  // Keyboard navigation effect
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tag = (document.activeElement?.tagName || "").toLowerCase();
+      if (tag === "input" || tag === "textarea" || (document.activeElement as HTMLElement)?.isContentEditable) {
+        return;
+      }
+
+      const total = filteredItems.length;
+      if (total === 0) return;
+
+      const current = focusedIndex ?? -1;
+
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = Math.min(current + 1, total - 1);
+        setFocusedIndex(next);
+        itemRefs.current.get(next)?.scrollIntoView({ block: "nearest" });
+        if (e.shiftKey) {
+          const item = filteredItems[next];
+          if (item.item_type === "note") {
+            if (!selectedNoteIdSet.has(item.id)) toggleNoteSelection(item.id);
+          } else {
+            if (!selectedIdSet.has(item.id)) toggleItemSelection(item.id);
+          }
+        }
+        return;
+      }
+
+      if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const next = Math.max(current - 1, 0);
+        setFocusedIndex(next);
+        itemRefs.current.get(next)?.scrollIntoView({ block: "nearest" });
+        if (e.shiftKey) {
+          const item = filteredItems[next];
+          if (item.item_type === "note") {
+            if (!selectedNoteIdSet.has(item.id)) toggleNoteSelection(item.id);
+          } else {
+            if (!selectedIdSet.has(item.id)) toggleItemSelection(item.id);
+          }
+        }
+        return;
+      }
+
+      if (e.key === "x" && current >= 0 && current < total) {
+        e.preventDefault();
+        const item = filteredItems[current];
+        if (item.item_type === "note") {
+          toggleNoteSelection(item.id);
+        } else {
+          toggleItemSelection(item.id);
+        }
+        return;
+      }
+
+      if ((e.key === "Enter" || e.key === "o") && current >= 0 && current < total) {
+        e.preventDefault();
+        const item = filteredItems[current];
+        if (item.item_type === "note") {
+          handleNoteClick(item.id);
+        } else {
+          handleItemClick(item.id);
+        }
+        return;
+      }
+
+      if (e.key === "e" && !showDismissedOnly) {
+        e.preventDefault();
+        if (selectedItemIds.length > 0) {
+          handleBulkDelete();
+        } else if (current >= 0 && current < total) {
+          const item = filteredItems[current];
+          if (item.item_type !== "note") {
+            deleteItem(item.id);
+          }
+        }
+        return;
+      }
+
+      if (e.key === "a" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSelectAll();
+        return;
+      }
+
+      if (e.key === "?") {
+        e.preventDefault();
+        setShortcutsOpen(true);
+        return;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [focusedIndex, filteredItems, selectedIdSet, selectedNoteIdSet, selectedItemIds, setFocusedIndex, toggleItemSelection, toggleNoteSelection, showDismissedOnly, handleSelectAll, deleteItem, handleBulkDelete, handleItemClick, handleNoteClick]);
+
+  // Reset focused index when filtered items change
+  useEffect(() => {
+    if (focusedIndex !== null && focusedIndex >= filteredItems.length) {
+      setFocusedIndex(filteredItems.length > 0 ? filteredItems.length - 1 : null);
+    }
+  }, [filteredItems.length, focusedIndex, setFocusedIndex]);
 
   const handleNoteGenerate = async (noteId: string) => {
     setIsGenerating(noteId, true);
@@ -450,6 +633,14 @@ export function InboxList() {
           </div>
         ) : (
           <>
+            {filteredItems.length > 0 && (
+              <Checkbox
+                checked={allSelected ? true : someSelected ? "indeterminate" : false}
+                onClick={handleSelectAll}
+                className="shrink-0"
+                aria-label="Select all"
+              />
+            )}
             <h2 className="min-w-0 truncate text-base font-bold">{headerTitle}</h2>
             <div className="flex-1" />
           </>
@@ -482,7 +673,7 @@ export function InboxList() {
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
+              <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
                 <DropdownMenuItem onClick={() => window.location.reload()}>
                   <RotateCw className="h-4 w-4" />
                   Reload page
@@ -490,6 +681,11 @@ export function InboxList() {
                 <DropdownMenuItem onClick={() => refreshInbox()}>
                   <RefreshCw className="h-4 w-4" />
                   Refresh
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => setShortcutsOpen(true)}>
+                  <Keyboard className="h-4 w-4" />
+                  Keyboard shortcuts
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -510,7 +706,7 @@ export function InboxList() {
                   )}
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
+              <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
                 <DropdownMenuItem onClick={() => window.location.reload()}>
                   <RotateCw className="h-4 w-4" />
                   Reload page
@@ -522,6 +718,11 @@ export function InboxList() {
                 <DropdownMenuItem onClick={fullSync} disabled={isSyncing}>
                   <RotateCcw className="h-4 w-4" />
                   Full sync (restore deleted items)
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => setShortcutsOpen(true)}>
+                  <Keyboard className="h-4 w-4" />
+                  Keyboard shortcuts
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -543,18 +744,23 @@ export function InboxList() {
       ) : (
       <ScrollArea className="min-h-0 flex-1">
           <div className="flex flex-col">
-            {filteredItems.map((item) => {
+            {filteredItems.map((item, index) => {
               if (item.item_type === "note") {
                 const project = projectMap.get(item.project_id);
                 return (
                   <NoteItem
                     key={`note-${item.id}`}
+                    ref={(el: HTMLElement | null) => {
+                      if (el) itemRefs.current.set(index, el);
+                      else itemRefs.current.delete(index);
+                    }}
                     note={item}
                     projectLabel={project ? `${project.owner}/${project.name}` : undefined}
                     isSelected={item.id === selectedNoteId}
                     isChecked={selectedNoteIdSet.has(item.id)}
+                    isFocused={index === focusedIndex}
                     isGenerating={isGenerating[item.id] || false}
-                    onToggleSelect={() => toggleNoteSelection(item.id)}
+                    onToggleSelect={(e: React.MouseEvent) => handleToggleSelectNote(item.id, index, e)}
                     onClick={() => handleNoteClick(item.id)}
                     onDelete={() => handleNoteDelete(item.id)}
                     onGenerate={() => handleNoteGenerate(item.id)}
@@ -567,6 +773,10 @@ export function InboxList() {
               return (
                 <InboxItem
                   key={`item-${item.id}`}
+                  ref={(el: HTMLElement | null) => {
+                    if (el) itemRefs.current.set(index, el);
+                    else itemRefs.current.delete(index);
+                  }}
                   item={item}
                   repoName={project ? `${project.owner}/${project.name}` : undefined}
                   platform={project?.platform}
@@ -574,7 +784,8 @@ export function InboxList() {
                   isAnalyzing={!!activeAnalyses[item.id]?.isStreaming}
                   hasAnalysis={analyzedItemIds.has(item.id)}
                   isChecked={selectedIdSet.has(item.id)}
-                  onToggleSelect={() => toggleItemSelection(item.id)}
+                  isFocused={index === focusedIndex}
+                  onToggleSelect={(e: React.MouseEvent) => handleToggleSelectItem(item.id, index, e)}
                   onClick={() => handleItemClick(item.id)}
                   onToggleStar={() => handleToggleStar(item)}
                   onMarkUnread={() => markUnread(item.id)}
@@ -614,6 +825,7 @@ export function InboxList() {
         />
       )}
       <CreateNoteDialog />
+      <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
     </div>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -71,10 +71,38 @@ const typeFilters: { value: ItemTypeFilter; label: string; icon: React.ReactNode
 
 export function Sidebar() {
   const { projects, selectedProjectIds, toggleProjectSelection, clearProjectSelection, fetchProjects } = useProjects();
-  const { setItems, itemTypeFilter, setItemTypeFilter, setCurrentPage, showAnalyzedOnly, setShowAnalyzedOnly, analyzedItemIds, showStarredOnly, setShowStarredOnly, showDismissedOnly, setShowDismissedOnly, items, themePreference, setThemePreference, refreshInbox } = useAppStore();
+  const { setItems, itemTypeFilter, setItemTypeFilter, setCurrentPage, showAnalyzedOnly, setShowAnalyzedOnly, analyzedItemIds, showStarredOnly, setShowStarredOnly, showDismissedOnly, setShowDismissedOnly, items, themePreference, setThemePreference, refreshInbox, dismissedCounts } = useAppStore();
   const [version, setVersion] = useState("");
+  // Items filtered by project + type filter (for "Show Only" counters)
+  const baseFilteredItems = useMemo(() => {
+    let result = items;
+    if (selectedProjectIds.length > 0) {
+      const selected = new Set(selectedProjectIds);
+      result = result.filter((i) => selected.has(i.project_id));
+    }
+    if (itemTypeFilter !== "all") {
+      result = result.filter((i) => i.item_type === itemTypeFilter);
+    }
+    return result;
+  }, [items, selectedProjectIds, itemTypeFilter]);
+
   const noteCount = useMemo(() => items.filter((i) => i.item_type === "note").length, [items]);
-  const analyzedNoteCount = useMemo(() => items.filter((i) => i.item_type === "note" && i.type_data.kind === "note" && i.type_data.draft_status === "ready" && !analyzedItemIds.has(i.id)).length, [items, analyzedItemIds]);
+  const starredCount = useMemo(() => baseFilteredItems.filter((i) => i.is_starred).length, [baseFilteredItems]);
+  const analyzedCount = useMemo(() => {
+    const analyzed = baseFilteredItems.filter((i) => analyzedItemIds.has(i.id));
+    const readyNotes = baseFilteredItems.filter((i) => i.item_type === "note" && i.type_data.kind === "note" && i.type_data.draft_status === "ready" && !analyzedItemIds.has(i.id));
+    return analyzed.length + readyNotes.length;
+  }, [baseFilteredItems, analyzedItemIds]);
+  const dismissedCount = useMemo(() => {
+    const selectedSet = selectedProjectIds.length > 0 ? new Set(selectedProjectIds) : null;
+    return dismissedCounts
+      .filter((c) => {
+        if (selectedSet && !selectedSet.has(c.project_id)) return false;
+        if (itemTypeFilter !== "all" && c.item_type !== itemTypeFilter) return false;
+        return true;
+      })
+      .reduce((sum, c) => sum + c.count, 0);
+  }, [dismissedCounts, selectedProjectIds, itemTypeFilter]);
 
   useEffect(() => {
     getVersion().then(setVersion);
@@ -131,8 +159,8 @@ export function Sidebar() {
           >
             <Sparkles className="h-4 w-4" />
             AI Analyzed
-            {(analyzedItemIds.size + analyzedNoteCount) > 0 && (
-              <span className="ml-auto text-xs text-muted-foreground">{analyzedItemIds.size + analyzedNoteCount}</span>
+            {analyzedCount > 0 && (
+              <span className="ml-auto text-xs text-muted-foreground">{analyzedCount}</span>
             )}
           </Button>
           <Button
@@ -147,10 +175,8 @@ export function Sidebar() {
           >
             <Star className="h-4 w-4" />
             Starred
-            {items.filter((i) => i.is_starred).length > 0 && (
-              <span className="ml-auto text-xs text-muted-foreground">
-                {items.filter((i) => i.is_starred).length}
-              </span>
+            {starredCount > 0 && (
+              <span className="ml-auto text-xs text-muted-foreground">{starredCount}</span>
             )}
           </Button>
           <Button
@@ -166,6 +192,9 @@ export function Sidebar() {
           >
             <EyeOff className="h-4 w-4" />
             Dismissed
+            {dismissedCount > 0 && (
+              <span className="ml-auto text-xs text-muted-foreground">{dismissedCount}</span>
+            )}
           </Button>
         </div>
       </div>

--- a/src/components/notes/NoteItem.tsx
+++ b/src/components/notes/NoteItem.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -34,8 +35,9 @@ interface NoteItemProps {
   projectLabel?: string;
   isSelected: boolean;
   isChecked: boolean;
+  isFocused?: boolean;
   isGenerating: boolean;
-  onToggleSelect: () => void;
+  onToggleSelect: (e: React.MouseEvent) => void;
   onClick: () => void;
   onDelete: () => void;
   onGenerate: () => void;
@@ -43,11 +45,12 @@ interface NoteItemProps {
   onToggleStar: () => void;
 }
 
-export function NoteItem({
+export const NoteItem = forwardRef<HTMLElement, NoteItemProps>(function NoteItem({
   note,
   projectLabel,
   isSelected,
   isChecked,
+  isFocused,
   isGenerating,
   onToggleSelect,
   onClick,
@@ -55,7 +58,7 @@ export function NoteItem({
   onGenerate,
   onEdit,
   onToggleStar,
-}: NoteItemProps) {
+}, ref) {
   const noteData = note.type_data.kind === "note" ? note.type_data : null;
   const status = noteData?.draft_status || "draft";
   const config = statusConfig[status] || statusConfig.draft;
@@ -69,8 +72,9 @@ export function NoteItem({
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <button
-          className={`note-item-enter block w-full border-b px-4 py-3.5 text-left transition-colors hover:bg-muted/50 ${
-            isSelected ? "bg-muted border-l-2 border-l-amber-500 dark:border-l-amber-400" : ""
+          ref={ref as React.Ref<HTMLButtonElement>}
+          className={`note-item-enter block w-full border-l-2 border-b px-4 py-3.5 text-left transition-colors hover:bg-muted/50 ${
+            isSelected ? "bg-muted border-l-amber-500 dark:border-l-amber-400" : isFocused ? "border-l-primary/30" : "border-l-transparent"
           }`}
           onClick={onClick}
         >
@@ -79,7 +83,7 @@ export function NoteItem({
               checked={isChecked}
               onClick={(e) => {
                 e.stopPropagation();
-                onToggleSelect();
+                onToggleSelect(e as unknown as React.MouseEvent);
               }}
               className="shrink-0"
             />
@@ -173,4 +177,4 @@ export function NoteItem({
       </ContextMenuContent>
     </ContextMenu>
   );
-}
+});

--- a/src/components/shared/KeyboardShortcutsDialog.tsx
+++ b/src/components/shared/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,114 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function Kbd({ children, wide }: { children: React.ReactNode; wide?: boolean }) {
+  return (
+    <kbd
+      className={`inline-flex h-[26px] items-center justify-center rounded-[5px] border border-border bg-gradient-to-b from-muted/80 to-muted px-1.5 font-mono text-[11px] font-semibold tracking-wide text-foreground/80 shadow-[0_1px_0_1px_var(--border),0_2px_3px_-1px_rgba(0,0,0,0.1)] ${wide ? "min-w-[52px]" : "min-w-[26px]"}`}
+    >
+      {children}
+    </kbd>
+  );
+}
+
+function Sep({ children }: { children: string }) {
+  return (
+    <span className="px-0.5 text-[10px] font-medium text-muted-foreground/40">{children}</span>
+  );
+}
+
+function ShortcutRow({ keys, action }: { keys: React.ReactNode; action: string }) {
+  return (
+    <div className="group flex items-center justify-between py-[7px] transition-colors">
+      <span className="text-[13px] text-muted-foreground group-hover:text-foreground transition-colors">{action}</span>
+      <div className="flex items-center gap-0.5">{keys}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-0.5">
+      <h3
+        className="mb-1 text-[11px] font-bold uppercase tracking-[0.12em] text-primary/70"
+        style={{ fontFamily: "'Syne', sans-serif" }}
+      >
+        {title}
+      </h3>
+      <div className="divide-y divide-border/50">{children}</div>
+    </div>
+  );
+}
+
+export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle className="text-base">Keyboard Shortcuts</DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground/70">
+            Navigate your inbox without leaving the keyboard
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 px-5 py-4">
+          <Section title="Navigation">
+            <ShortcutRow
+              keys={<><Kbd>j</Kbd><Sep>/</Sep><Kbd>↓</Kbd></>}
+              action="Move down"
+            />
+            <ShortcutRow
+              keys={<><Kbd>k</Kbd><Sep>/</Sep><Kbd>↑</Kbd></>}
+              action="Move up"
+            />
+            <ShortcutRow
+              keys={<><Kbd wide>Enter</Kbd><Sep>/</Sep><Kbd>o</Kbd></>}
+              action="Open item"
+            />
+          </Section>
+
+          <Section title="Selection">
+            <ShortcutRow keys={<Kbd>x</Kbd>} action="Toggle selection" />
+            <ShortcutRow
+              keys={<><Kbd>⇧</Kbd><Sep>+</Sep><Kbd>j</Kbd><Sep>/</Sep><Kbd>↓</Kbd></>}
+              action="Select & move down"
+            />
+            <ShortcutRow
+              keys={<><Kbd>⇧</Kbd><Sep>+</Sep><Kbd>k</Kbd><Sep>/</Sep><Kbd>↑</Kbd></>}
+              action="Select & move up"
+            />
+            <ShortcutRow
+              keys={<><Kbd>⌘</Kbd><Sep>+</Sep><Kbd>a</Kbd></>}
+              action="Select all"
+            />
+            <ShortcutRow
+              keys={<><Kbd>⇧</Kbd><Sep>+</Sep><span className="text-[11px] font-medium text-muted-foreground/60">Click</span></>}
+              action="Range select"
+            />
+          </Section>
+
+          <Section title="Actions">
+            <ShortcutRow keys={<Kbd>e</Kbd>} action="Dismiss selected / focused" />
+            <ShortcutRow keys={<Kbd>?</Kbd>} action="Show this help" />
+          </Section>
+        </div>
+
+        <div className="border-t bg-muted/30 px-5 py-2.5">
+          <p className="text-center text-[11px] text-muted-foreground/50">
+            Press <Kbd>Esc</Kbd> to close
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -150,6 +150,7 @@ export function useItems() {
       if (showDismissedOnly) {
         const response = await api.listDismissedItems({ itemType: typeFilter, searchQuery: search });
         setItems(response.items);
+        useItemStore.setState({ dismissedCounts: response.dismissed_counts });
       } else {
         const [response, analyzedIds] = await Promise.all([
           api.listItems({ itemType: typeFilter, searchQuery: search }),
@@ -157,6 +158,7 @@ export function useItems() {
         ]);
         setItems(response.items);
         setAnalyzedItemIds(analyzedIds);
+        useItemStore.setState({ dismissedCounts: response.dismissed_counts });
       }
     } catch (err) {
       toast.error("Failed to fetch items", { description: errorMessage(err) });
@@ -207,6 +209,8 @@ export function useItems() {
       removeItem(id);
       try {
         await api.deleteItem(id);
+        // Refresh to update dismissed counts
+        await useItemStore.getState().fetchInbox();
       } catch (err) {
         if (item) useAppStore.getState().mergeItems([item]);
         toast.error("Failed to delete item", {
@@ -223,6 +227,8 @@ export function useItems() {
       removeItem(id);
       try {
         await api.restoreItem(id);
+        // Refresh to update dismissed counts
+        await useItemStore.getState().fetchInbox();
       } catch (err) {
         toast.error("Failed to restore item", {
           description: errorMessage(err),

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -110,6 +110,7 @@ interface AppState {
   // Dismissed filter
   showDismissedOnly: boolean;
   setShowDismissedOnly: (show: boolean) => void;
+  dismissedCounts: import("@/types").DismissedCount[];
 
   // Refresh interval
   refreshInterval: number;
@@ -207,6 +208,7 @@ function getCompositeState(): AppState {
     // Dismissed
     showDismissedOnly: item.showDismissedOnly,
     setShowDismissedOnly: item.setShowDismissedOnly,
+    dismissedCounts: item.dismissedCounts,
 
     // UI
     refreshInterval: ui.refreshInterval,

--- a/src/stores/draftIssueStore.ts
+++ b/src/stores/draftIssueStore.ts
@@ -20,6 +20,8 @@ interface NoteState {
   selectedNoteIds: string[];
   toggleNoteSelection: (id: string) => void;
   clearNoteSelection: () => void;
+  lastClickedNoteIndex: number | null;
+  setLastClickedNoteIndex: (index: number | null) => void;
 
   // Per-note loading states
   isGenerating: Record<string, boolean>;
@@ -50,7 +52,9 @@ export const useDraftIssueStore = create<NoteState>((set) => ({
         ? state.selectedNoteIds.filter((i) => i !== id)
         : [...state.selectedNoteIds, id],
     })),
-  clearNoteSelection: () => set({ selectedNoteIds: [] }),
+  clearNoteSelection: () => set({ selectedNoteIds: [], lastClickedNoteIndex: null }),
+  lastClickedNoteIndex: null,
+  setLastClickedNoteIndex: (index) => set({ lastClickedNoteIndex: index }),
 
   isGenerating: {},
   setIsGenerating: (id, value) =>

--- a/src/stores/itemStore.ts
+++ b/src/stores/itemStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { listItems as listItemsApi, listDismissedItems as listDismissedItemsApi } from "@/lib/tauri";
-import type { Item, ItemTypeFilter } from "@/types";
+import type { Item, ItemTypeFilter, DismissedCount } from "@/types";
 import { useProjectStore } from "./projectStore";
 
 interface ItemState {
@@ -21,6 +21,12 @@ interface ItemState {
   selectAllItems: (ids: string[]) => void;
   clearSelection: () => void;
 
+  // Focus & range selection
+  lastClickedIndex: number | null;
+  focusedIndex: number | null;
+  setLastClickedIndex: (index: number | null) => void;
+  setFocusedIndex: (index: number | null) => void;
+
   // Filters
   searchQuery: string;
   setSearchQuery: (query: string) => void;
@@ -30,6 +36,9 @@ interface ItemState {
   setShowStarredOnly: (show: boolean) => void;
   showDismissedOnly: boolean;
   setShowDismissedOnly: (show: boolean) => void;
+
+  // Dismissed counts (per project+type)
+  dismissedCounts: DismissedCount[];
 
   // Pagination
   nextCursor: string | null;
@@ -95,7 +104,12 @@ export const useItemStore = create<ItemState>((set) => ({
         : [...state.selectedItemIds, id],
     })),
   selectAllItems: (ids) => set({ selectedItemIds: ids }),
-  clearSelection: () => set({ selectedItemIds: [] }),
+  clearSelection: () => set({ selectedItemIds: [], lastClickedIndex: null }),
+
+  lastClickedIndex: null,
+  focusedIndex: null,
+  setLastClickedIndex: (index) => set({ lastClickedIndex: index }),
+  setFocusedIndex: (index) => set({ focusedIndex: index }),
 
   searchQuery: "",
   setSearchQuery: (query) => set({ searchQuery: query, selectedItemIds: [] }),
@@ -108,6 +122,8 @@ export const useItemStore = create<ItemState>((set) => ({
 
   showDismissedOnly: false,
   setShowDismissedOnly: (show) => set({ showDismissedOnly: show, selectedItemIds: [] }),
+
+  dismissedCounts: [],
 
   nextCursor: null,
   hasMore: false,
@@ -143,6 +159,7 @@ export const useItemStore = create<ItemState>((set) => ({
         items: response.items,
         nextCursor: response.next_cursor,
         hasMore: response.has_more,
+        dismissedCounts: response.dismissed_counts,
       });
     } catch (e) {
       console.error("Failed to fetch inbox:", e);
@@ -181,6 +198,7 @@ export const useItemStore = create<ItemState>((set) => ({
         items: [...prev.items, ...response.items],
         nextCursor: response.next_cursor,
         hasMore: response.has_more,
+        dismissedCounts: response.dismissed_counts,
         isLoadingMore: false,
       }));
     } catch (e) {

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -55,8 +55,15 @@ export interface Item {
   updated_at: string;
 }
 
+export interface DismissedCount {
+  project_id: string;
+  item_type: string;
+  count: number;
+}
+
 export interface ItemPageResponse {
   items: Item[];
   next_cursor: string | null;
   has_more: boolean;
+  dismissed_counts: DismissedCount[];
 }


### PR DESCRIPTION
Adds a "Keyboard shortcuts" menu item to both overflow menus (notes-only and default views) so users can discover the shortcuts dialog without knowing the ? hotkey. Also fixes a bug where arrow keys would reopen the dropdown after closing it.