### PR TITLE
fix: persist note count badge across type filter changes

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -71,7 +71,7 @@ const typeFilters: { value: ItemTypeFilter; label: string; icon: React.ReactNode
 
 export function Sidebar() {
   const { projects, selectedProjectIds, toggleProjectSelection, clearProjectSelection, fetchProjects } = useProjects();
-  const { setItems, itemTypeFilter, setItemTypeFilter, setCurrentPage, showAnalyzedOnly, setShowAnalyzedOnly, analyzedItemIds, showStarredOnly, setShowStarredOnly, showDismissedOnly, setShowDismissedOnly, items, themePreference, setThemePreference, refreshInbox, dismissedCounts } = useAppStore();
+  const { setItems, itemTypeFilter, setItemTypeFilter, setCurrentPage, showAnalyzedOnly, setShowAnalyzedOnly, analyzedItemIds, showStarredOnly, setShowStarredOnly, showDismissedOnly, setShowDismissedOnly, items, themePreference, setThemePreference, refreshInbox, dismissedCounts, draftNoteCount } = useAppStore();
   const [version, setVersion] = useState("");
   // Items filtered by project + type filter (for "Show Only" counters)
   const baseFilteredItems = useMemo(() => {
@@ -86,7 +86,7 @@ export function Sidebar() {
     return result;
   }, [items, selectedProjectIds, itemTypeFilter]);
 
-  const noteCount = useMemo(() => items.filter((i) => i.item_type === "note").length, [items]);
+  const noteCount = draftNoteCount;
   const starredCount = useMemo(() => baseFilteredItems.filter((i) => i.is_starred).length, [baseFilteredItems]);
   const analyzedCount = useMemo(() => {
     const analyzed = baseFilteredItems.filter((i) => analyzedItemIds.has(i.id));

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -148,17 +148,21 @@ export function useItems() {
       const typeFilter = itemTypeFilter === "all" ? undefined : itemTypeFilter;
       const search = searchQuery.trim() || undefined;
       if (showDismissedOnly) {
-        const response = await api.listDismissedItems({ itemType: typeFilter, searchQuery: search });
+        const [response, noteCount] = await Promise.all([
+          api.listDismissedItems({ itemType: typeFilter, searchQuery: search }),
+          api.getDraftIssueCount(),
+        ]);
         setItems(response.items);
-        useItemStore.setState({ dismissedCounts: response.dismissed_counts });
+        useItemStore.setState({ dismissedCounts: response.dismissed_counts, draftNoteCount: noteCount });
       } else {
-        const [response, analyzedIds] = await Promise.all([
+        const [response, analyzedIds, noteCount] = await Promise.all([
           api.listItems({ itemType: typeFilter, searchQuery: search }),
           api.getAnalyzedItemIds(),
+          api.getDraftIssueCount(),
         ]);
         setItems(response.items);
         setAnalyzedItemIds(analyzedIds);
-        useItemStore.setState({ dismissedCounts: response.dismissed_counts });
+        useItemStore.setState({ dismissedCounts: response.dismissed_counts, draftNoteCount: noteCount });
       }
     } catch (err) {
       toast.error("Failed to fetch items", { description: errorMessage(err) });

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -112,6 +112,9 @@ interface AppState {
   setShowDismissedOnly: (show: boolean) => void;
   dismissedCounts: import("@/types").DismissedCount[];
 
+  // Persistent note count
+  draftNoteCount: number;
+
   // Refresh interval
   refreshInterval: number;
   setRefreshInterval: (interval: number) => void;
@@ -209,6 +212,9 @@ function getCompositeState(): AppState {
     showDismissedOnly: item.showDismissedOnly,
     setShowDismissedOnly: item.setShowDismissedOnly,
     dismissedCounts: item.dismissedCounts,
+
+    // Note count
+    draftNoteCount: item.draftNoteCount,
 
     // UI
     refreshInterval: ui.refreshInterval,

--- a/src/stores/itemStore.ts
+++ b/src/stores/itemStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { listItems as listItemsApi, listDismissedItems as listDismissedItemsApi } from "@/lib/tauri";
+import { listItems as listItemsApi, listDismissedItems as listDismissedItemsApi, getDraftIssueCount } from "@/lib/tauri";
 import type { Item, ItemTypeFilter, DismissedCount } from "@/types";
 import { useProjectStore } from "./projectStore";
 
@@ -39,6 +39,9 @@ interface ItemState {
 
   // Dismissed counts (per project+type)
   dismissedCounts: DismissedCount[];
+
+  // Persistent note count (independent of type filter)
+  draftNoteCount: number;
 
   // Pagination
   nextCursor: string | null;
@@ -125,6 +128,8 @@ export const useItemStore = create<ItemState>((set) => ({
 
   dismissedCounts: [],
 
+  draftNoteCount: 0,
+
   nextCursor: null,
   hasMore: false,
   isLoadingMore: false,
@@ -141,25 +146,29 @@ export const useItemStore = create<ItemState>((set) => ({
       const starredOnly = filters?.starredOnly ?? itemState.showStarredOnly;
 
       const searchQuery = itemState.searchQuery.trim() || undefined;
-      const response = itemState.showDismissedOnly
-        ? await listDismissedItemsApi({
-            projectId: projectIds?.[0],
-            itemType,
-            searchQuery,
-            pageSize: 50,
-          })
-        : await listItemsApi({
-            projectId: projectIds?.[0],
-            itemType,
-            starredOnly: starredOnly || undefined,
-            searchQuery,
-            pageSize: 50,
-          });
+      const [response, noteCount] = await Promise.all([
+        itemState.showDismissedOnly
+          ? listDismissedItemsApi({
+              projectId: projectIds?.[0],
+              itemType,
+              searchQuery,
+              pageSize: 50,
+            })
+          : listItemsApi({
+              projectId: projectIds?.[0],
+              itemType,
+              starredOnly: starredOnly || undefined,
+              searchQuery,
+              pageSize: 50,
+            }),
+        getDraftIssueCount(),
+      ]);
       set({
         items: response.items,
         nextCursor: response.next_cursor,
         hasMore: response.has_more,
         dismissedCounts: response.dismissed_counts,
+        draftNoteCount: noteCount,
       });
     } catch (e) {
       console.error("Failed to fetch inbox:", e);


### PR DESCRIPTION
## Summary
- The Notes badge counter in the sidebar disappeared when switching to Issues/PRs/Discussions tabs
- Root cause: the `items` array only contained the filtered type, so `noteCount` computed from it became 0
- Fix: fetch draft note count independently via `getDraftIssueCount` API so the badge persists across all filter views
- Count is fetched in parallel with items to avoid extra latency

## Test plan
- [ ] Switch to Issues tab — verify Notes badge still shows the correct count
- [ ] Switch to PRs tab — verify Notes badge still shows
- [ ] Create/delete a note — verify the count updates
- [ ] Toggle Dismissed view — verify count remains accurate

Closes #10

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)