### PR TITLE
feat: add bulk publish action for analyzed notes

### DIFF
--- a/src/components/layout/InboxList.tsx
+++ b/src/components/layout/InboxList.tsx
@@ -25,6 +25,15 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toast } from "sonner";
 import * as api from "@/lib/tauri";
 import type { AnalysisAction } from "@/types";
@@ -55,6 +64,7 @@ export function InboxList() {
   } = useItemStore();
 
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [publishConfirmOpen, setPublishConfirmOpen] = useState(false);
   const [localSearch, setLocalSearch] = useState(searchQuery);
   const [isSearchOpen, setIsSearchOpen] = useState(searchQuery.length > 0);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -444,6 +454,25 @@ export function InboxList() {
     }
   };
 
+  const handleBulkNotePublish = async () => {
+    const readyNotes = selectedNotes.filter((n) => n.type_data.kind === "note" && n.type_data.draft_status === "ready");
+    clearNoteSelection();
+
+    let successCount = 0;
+    for (const note of readyNotes) {
+      try {
+        await api.submitDraftToProvider(note.id);
+        successCount++;
+      } catch (err) {
+        toast.error(`Failed to publish note`, { description: errorMessage(err) });
+      }
+    }
+    if (successCount > 0) {
+      toast.success(`Published ${successCount} issue${successCount > 1 ? "s" : ""}`);
+    }
+    await refreshInbox();
+  };
+
   const handleCreateNote = () => {
     if (selectedProjectIds.length === 1) {
       openCreateNote(selectedProjectIds[0]);
@@ -820,12 +849,31 @@ export function InboxList() {
         <NoteBulkActionBar
           selectedNotes={selectedNotes}
           onGenerateIssue={handleBulkNoteGenerate}
+          onPublish={() => setPublishConfirmOpen(true)}
           onDelete={handleBulkNoteDelete}
           onClearSelection={clearNoteSelection}
         />
       )}
       <CreateNoteDialog />
       <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+      <Dialog open={publishConfirmOpen} onOpenChange={setPublishConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Publish Notes as Issues</DialogTitle>
+            <DialogDescription>
+              This will create {selectedNotes.filter((n) => n.type_data.kind === "note" && n.type_data.draft_status === "ready").length} issue{selectedNotes.filter((n) => n.type_data.kind === "note" && n.type_data.draft_status === "ready").length !== 1 ? "s" : ""} on the respective repositories. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button onClick={() => { setPublishConfirmOpen(false); handleBulkNotePublish(); }}>
+              Publish
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/notes/NoteBulkActionBar.tsx
+++ b/src/components/notes/NoteBulkActionBar.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@/components/ui/button";
-import { Sparkles, Trash2, X } from "lucide-react";
+import { Sparkles, Trash2, X, Upload } from "lucide-react";
 import type { Item } from "@/types";
 
 interface NoteBulkActionBarProps {
   selectedNotes: Item[];
   onGenerateIssue: () => void;
+  onPublish: () => void;
   onDelete: () => void;
   onClearSelection: () => void;
 }
@@ -12,12 +13,14 @@ interface NoteBulkActionBarProps {
 export function NoteBulkActionBar({
   selectedNotes,
   onGenerateIssue,
+  onPublish,
   onDelete,
   onClearSelection,
 }: NoteBulkActionBarProps) {
   if (selectedNotes.length === 0) return null;
 
   const hasDrafts = selectedNotes.some((n) => n.type_data.kind === "note" && n.type_data.draft_status === "draft");
+  const hasReady = selectedNotes.some((n) => n.type_data.kind === "note" && n.type_data.draft_status === "ready");
 
   return (
     <div className="flex items-center gap-2 border-t border-t-amber-500/20 dark:border-t-amber-400/20 bg-background px-4 py-2.5">
@@ -29,6 +32,12 @@ export function NoteBulkActionBar({
           <Button variant="ghost" size="sm" onClick={onGenerateIssue}>
             <Sparkles className="mr-1 h-3.5 w-3.5" />
             Generate Issue
+          </Button>
+        )}
+        {hasReady && (
+          <Button variant="ghost" size="sm" onClick={onPublish}>
+            <Upload className="mr-1 h-3.5 w-3.5" />
+            Publish
           </Button>
         )}
         <Button


### PR DESCRIPTION
## Summary

- Adds a **Publish** button to the notes bulk action bar, visible when at least one selected note has `ready` (analyzed) status
- Shows a confirmation dialog before publishing to prevent accidental bulk operations
- Publishes each ready note as a GitHub/GitLab issue sequentially, with per-note error toasts and a success summary toast
- Only notes with `draft_status === "ready"` are published; unanalyzed notes are excluded

## Test plan

- [ ] Select multiple notes including some with "ready" status → verify "Publish" button appears
- [ ] Select only "draft" notes → verify "Publish" button does NOT appear
- [ ] Click "Publish" → verify confirmation dialog appears with correct count
- [ ] Cancel the dialog → verify nothing is published
- [ ] Confirm publish → verify issues are created and success toast appears
- [ ] If a note fails to publish → verify error toast appears for that note while others succeed

Closes #12

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)