### PR TITLE
feat: add keyboard shortcuts Cmd+1-5 to switch between tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,12 +77,21 @@ function App() {
     initApp();
   }, [initApp]);
 
-  // Cmd+N to open create note dialog
+  // Cmd+N to open create note dialog, Cmd+1-5 to switch tabs
   useEffect(() => {
+    const tabFilters = ["all", "note", "issue", "pr", "discussion"] as const;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.metaKey && e.key === "n") {
         e.preventDefault();
         useDraftIssueStore.getState().openCreateNote();
+        return;
+      }
+      if (e.metaKey && !e.shiftKey && !e.altKey) {
+        const num = parseInt(e.key, 10);
+        if (num >= 1 && num <= 5) {
+          e.preventDefault();
+          useAppStore.getState().setItemTypeFilter(tabFilters[num - 1]);
+        }
       }
     };
     window.addEventListener("keydown", handleKeyDown);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -124,7 +124,7 @@ export function Sidebar() {
           Filters
         </p>
         <div className="flex flex-col gap-1">
-          {typeFilters.map((f) => (
+          {typeFilters.map((f, index) => (
             <Button
               key={f.value}
               variant={itemTypeFilter === f.value ? "secondary" : "ghost"}
@@ -138,6 +138,9 @@ export function Sidebar() {
                 <span className="ml-auto flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500/15 dark:bg-amber-400/15 px-1 text-[10px] font-semibold tabular-nums text-amber-600 dark:text-amber-400">
                   {noteCount}
                 </span>
+              )}
+              {!(f.value === "note" && noteCount > 0) && (
+                <span className="ml-auto text-[10px] text-muted-foreground/50">⌘{index + 1}</span>
               )}
             </Button>
           ))}

--- a/src/components/shared/KeyboardShortcutsDialog.tsx
+++ b/src/components/shared/KeyboardShortcutsDialog.tsx
@@ -75,6 +75,10 @@ export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcut
               keys={<><Kbd wide>Enter</Kbd><Sep>/</Sep><Kbd>o</Kbd></>}
               action="Open item"
             />
+            <ShortcutRow
+              keys={<><Kbd>⌘</Kbd><Sep>+</Sep><Kbd>1</Kbd><Sep>–</Sep><Kbd>5</Kbd></>}
+              action="Switch tab (All / Notes / Issues / PRs / Discussions)"
+            />
           </Section>
 
           <Section title="Selection">


### PR DESCRIPTION
## Summary

- Adds `Cmd+1` through `Cmd+5` keyboard shortcuts to quickly switch between filter tabs (All, Notes, Issues, PRs, Discussions)
- Displays visual shortcut hints (⌘1–⌘5) next to each tab label in the sidebar
- Documents the new shortcuts in the keyboard shortcuts dialog

## Test plan

- [ ] Press `Cmd+1` → verify "All" tab is selected
- [ ] Press `Cmd+2` → verify "Notes" tab is selected
- [ ] Press `Cmd+3` → verify "Issues" tab is selected
- [ ] Press `Cmd+4` → verify "PRs" tab is selected
- [ ] Press `Cmd+5` → verify "Discussions" tab is selected
- [ ] Verify shortcut hints appear next to each tab label in sidebar
- [ ] Open keyboard shortcuts dialog (`?`) → verify new shortcuts are listed
- [ ] Verify shortcuts work regardless of focus state (input fields excluded)

Closes #11

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)