### PR TITLE
feat: add Cmd+N and Cmd+R keyboard shortcuts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,16 +77,22 @@ function App() {
     initApp();
   }, [initApp]);
 
-  // Cmd+N to open create note dialog, Cmd+1-5 to switch tabs
+  // Cmd+N to open create note dialog, Cmd+R to refresh, Cmd+1-5 to switch tabs
   useEffect(() => {
     const tabFilters = ["all", "note", "issue", "pr", "discussion"] as const;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.metaKey && e.key === "n") {
+      if (!e.metaKey) return;
+      if (e.key === "n") {
         e.preventDefault();
         useDraftIssueStore.getState().openCreateNote();
         return;
       }
-      if (e.metaKey && !e.shiftKey && !e.altKey) {
+      if (e.key === "r") {
+        e.preventDefault();
+        useAppStore.getState().refreshInbox();
+        return;
+      }
+      if (!e.shiftKey && !e.altKey) {
         const num = parseInt(e.key, 10);
         if (num >= 1 && num <= 5) {
           e.preventDefault();

--- a/src/components/shared/KeyboardShortcutsDialog.tsx
+++ b/src/components/shared/KeyboardShortcutsDialog.tsx
@@ -103,6 +103,14 @@ export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcut
 
           <Section title="Actions">
             <ShortcutRow keys={<Kbd>e</Kbd>} action="Dismiss selected / focused" />
+            <ShortcutRow
+              keys={<><Kbd>⌘</Kbd><Sep>+</Sep><Kbd>n</Kbd></>}
+              action="Create new note"
+            />
+            <ShortcutRow
+              keys={<><Kbd>⌘</Kbd><Sep>+</Sep><Kbd>r</Kbd></>}
+              action="Refresh inbox"
+            />
             <ShortcutRow keys={<Kbd>?</Kbd>} action="Show this help" />
           </Section>
         </div>


### PR DESCRIPTION
## Summary

- Adds `Cmd+R` keyboard shortcut to refresh the inbox
- Documents both `Cmd+N` (create note) and `Cmd+R` (refresh) in the keyboard shortcuts dialog

## Test plan

- [ ] Press `Cmd+N` → verify create note dialog opens
- [ ] Press `Cmd+R` → verify inbox refreshes
- [ ] Open keyboard shortcuts dialog (`?`) → verify both shortcuts are listed
- [ ] Verify `Cmd+R` overrides browser reload (Tauri app context)

Closes #6

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)