### PR TITLE
feat: extract refresh to dedicated button in toolbar

### DIFF
--- a/src/components/layout/InboxList.tsx
+++ b/src/components/layout/InboxList.tsx
@@ -666,67 +666,44 @@ export function InboxList() {
           >
             <Plus className="h-4 w-4" />
           </Button>
-          {isNotesOnly ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="More options">
-                  <MoreVertical className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
-                <DropdownMenuItem onClick={() => window.location.reload()}>
-                  <RotateCw className="h-4 w-4" />
-                  Reload page
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => refreshInbox()}>
-                  <RefreshCw className="h-4 w-4" />
-                  Refresh
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => setShortcutsOpen(true)}>
-                  <Keyboard className="h-4 w-4" />
-                  Keyboard shortcuts
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  disabled={isSyncing || selectedProjectIds.length > 1}
-                  aria-label="Sync options"
-                >
-                  {isSyncing ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <MoreVertical className="h-4 w-4" />
-                  )}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
-                <DropdownMenuItem onClick={() => window.location.reload()}>
-                  <RotateCw className="h-4 w-4" />
-                  Reload page
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={syncItems} disabled={isSyncing}>
-                  <RefreshCw className="h-4 w-4" />
-                  Refresh
-                </DropdownMenuItem>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={isNotesOnly ? () => refreshInbox() : syncItems}
+            disabled={!isNotesOnly && isSyncing}
+            aria-label="Refresh"
+          >
+            {!isNotesOnly && isSyncing ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="More options">
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
+              <DropdownMenuItem onClick={() => window.location.reload()}>
+                <RotateCw className="h-4 w-4" />
+                Reload page
+              </DropdownMenuItem>
+              {!isNotesOnly && (
                 <DropdownMenuItem onClick={fullSync} disabled={isSyncing}>
                   <RotateCcw className="h-4 w-4" />
                   Full sync (restore deleted items)
                 </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => setShortcutsOpen(true)}>
-                  <Keyboard className="h-4 w-4" />
-                  Keyboard shortcuts
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => setShortcutsOpen(true)}>
+                <Keyboard className="h-4 w-4" />
+                Keyboard shortcuts
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Adds a dedicated refresh button (with `RefreshCw` icon) to the inbox header toolbar, visible at all times
- Shows a loading spinner when syncing is in progress
- Removes the duplicate "Refresh" entry from the overflow menu
- Overflow menu now contains: Reload page, Full sync (non-notes view), and Keyboard shortcuts

## Test plan

- [ ] Verify refresh button is visible in the toolbar header
- [ ] Click refresh button → verify items are refreshed
- [ ] Verify spinner shows during sync
- [ ] Verify overflow menu no longer has duplicate "Refresh" entry
- [ ] Switch to Notes tab → verify refresh button works for notes too

Closes #7

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)