### PR TITLE
feat: enable refresh for multiple selected projects

### DIFF
--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -108,13 +108,15 @@ export function useItems() {
         return;
       }
       managerRef.current?.syncProject(selectedProjectIds[0]);
-    } else if (selectedProjectIds.length === 0) {
-      const syncEnabled = projects.filter((p) => p.sync_enabled);
-      if (syncEnabled.length === 0) {
+    } else {
+      const candidates = selectedProjectIds.length > 1
+        ? projects.filter((p) => selectedProjectIds.includes(p.id) && p.sync_enabled)
+        : projects.filter((p) => p.sync_enabled);
+      if (candidates.length === 0) {
         toast.error("No projects with sync enabled");
         return;
       }
-      managerRef.current?.syncMultipleProjects(syncEnabled.map((p) => p.id));
+      managerRef.current?.syncMultipleProjects(candidates.map((p) => p.id));
     }
   }, [selectedProjectIds, syncDisabled, projects]);
 
@@ -127,13 +129,15 @@ export function useItems() {
         return;
       }
       managerRef.current?.fullSyncProject(projectId);
-    } else if (selectedProjectIds.length === 0) {
-      const syncEnabled = projects.filter((p) => p.sync_enabled);
-      if (syncEnabled.length === 0) {
+    } else {
+      const candidates = selectedProjectIds.length > 1
+        ? projects.filter((p) => selectedProjectIds.includes(p.id) && p.sync_enabled)
+        : projects.filter((p) => p.sync_enabled);
+      if (candidates.length === 0) {
         toast.error("No projects with sync enabled");
         return;
       }
-      for (const p of syncEnabled) {
+      for (const p of candidates) {
         managerRef.current?.fullSyncProject(p.id);
       }
     }


### PR DESCRIPTION
## Summary

- Removes the restriction that disabled the sync menu when more than one project was selected
- Both regular sync and full sync now work with multiple selected projects, syncing all that have sync enabled
- Shows appropriate error if none of the selected projects have sync enabled

## Test plan

- [ ] Select 2+ projects → verify overflow menu is no longer disabled
- [ ] Click Refresh with multiple projects selected → verify all are synced
- [ ] Click Full sync with multiple projects selected → verify all are fully synced
- [ ] Select projects where some have sync disabled → verify only enabled ones sync
- [ ] Select only disabled projects → verify error toast appears

Closes #8

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)