### PR TITLE
feat: center toast notification above bottom action row

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,7 +182,7 @@ function App() {
             )}
           </div>
         )}
-        <Toaster position="bottom-right" />
+        <Toaster position="bottom-center" offset={48} />
       </TooltipProvider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary

- Changes toast position from `bottom-right` to `bottom-center`
- Adds a 48px offset to position toasts above the bulk action bars
- Prevents toast notifications from overlapping with action buttons

## Test plan

- [ ] Trigger a toast (e.g., publish a note, star an item) → verify it appears centered at the bottom
- [ ] Open bulk action bar → verify toast doesn't overlap with action buttons
- [ ] Verify toast is still fully visible and readable

Closes #13

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)