### PR TITLE
feat: rename 'AI is structuring your note' to 'Ossue is paraphrasing your note'

### DIFF
--- a/src/components/notes/NotePanel.tsx
+++ b/src/components/notes/NotePanel.tsx
@@ -190,7 +190,7 @@ function ProcessingView() {
     <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
       <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
       <p className="text-sm text-muted-foreground">Generating issue...</p>
-      <p className="text-xs text-muted-foreground/60">AI is structuring your note</p>
+      <p className="text-xs text-muted-foreground/60">Ossue is paraphrasing your note</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Updates the loading text shown during note generation from "AI is structuring your note" to "Ossue is paraphrasing your note" for branding consistency

## Test plan

- [ ] Create a note and click Generate → verify the loading text reads "Ossue is paraphrasing your note"

Closes #18

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)