### PR TITLE
fix: remove inline CMD shortcut labels from filter UI

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -124,7 +124,7 @@ export function Sidebar() {
           Filters
         </p>
         <div className="flex flex-col gap-1">
-          {typeFilters.map((f, index) => (
+          {typeFilters.map((f) => (
             <Button
               key={f.value}
               variant={itemTypeFilter === f.value ? "secondary" : "ghost"}
@@ -138,9 +138,6 @@ export function Sidebar() {
                 <span className="ml-auto flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500/15 dark:bg-amber-400/15 px-1 text-[10px] font-semibold tabular-nums text-amber-600 dark:text-amber-400">
                   {noteCount}
                 </span>
-              )}
-              {!(f.value === "note" && noteCount > 0) && (
-                <span className="ml-auto text-[10px] text-muted-foreground/50">⌘{index + 1}</span>
               )}
             </Button>
           ))}


### PR DESCRIPTION
## Summary

- Removes the inline ⌘1–⌘5 shortcut labels from filter buttons in the sidebar
- Eliminates visual collision between shortcut labels and counter badges
- Keyboard shortcuts remain fully functional and are documented in the shortcuts dialog (`?`)

## Test plan

- [ ] Verify filter buttons no longer show ⌘1–⌘5 labels
- [ ] Verify note counter badge displays cleanly without overlap
- [ ] Verify Cmd+1–5 shortcuts still work
- [ ] Press `?` → verify shortcuts are listed in the dialog

Closes #28

🤖 Generated with [Ossue](https://github.com/kaplanelad/ossue)