### PR TITLE
fix: use --system-prompt flag for Claude CLI draft issue generation

### DIFF
--- a/src-tauri/src/commands/draft_issues.rs
+++ b/src-tauri/src/commands/draft_issues.rs
@@ -516,12 +516,14 @@ pub async fn generate_issue_from_draft(
             }
         };
 
-        let prompt_text = format!(
-            "System: {}\n\nUser: {}",
-            DRAFT_ISSUE_SYSTEM_PROMPT, user_message
-        );
-
-        let mut args = vec!["-p".to_string(), prompt_text];
+        let mut args = vec![
+            "-p".to_string(),
+            user_message.clone(),
+            "--system-prompt".to_string(),
+            DRAFT_ISSUE_SYSTEM_PROMPT.to_string(),
+            "--output-format".to_string(),
+            "text".to_string(),
+        ];
         if let Some(ref m) = ai_model {
             args.push("--model".to_string());
             args.push(m.clone());


### PR DESCRIPTION
## Summary

- Fix CLI mode draft issue generation failing to parse AI response as JSON
- Use `--system-prompt` flag instead of embedding system prompt inline in `-p` text
- Add `--output-format text` to get clean output

Closes #32

## Test plan

- [ ] Generate a draft issue using CLI mode and verify JSON parsing succeeds
- [ ] Verify API mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)