### PR TITLE
fix: show issue/PR badge counters regardless of button selection state

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -136,7 +136,7 @@ export function Sidebar() {
               key={f.value}
               variant={itemTypeFilter === f.value ? "secondary" : "ghost"}
               size="sm"
-              className={`justify-start gap-2 ${itemTypeFilter === f.value ? (f.value === "note" ? "border-l-2 border-l-amber-500 dark:border-l-amber-400" : "border-l-2 border-l-primary") : ""}`}
+              className={`w-full !justify-start gap-2 ${itemTypeFilter === f.value ? (f.value === "note" ? "border-l-2 border-l-amber-500 dark:border-l-amber-400" : "border-l-2 border-l-primary") : ""}`}
               onClick={() => handleTypeFilterClick(f.value)}
             >
               {f.icon}


### PR DESCRIPTION
## Summary

- Add `w-full` to type filter buttons so the flex container spans full width
- Use `!justify-start` to force-override the Button component's base `justify-center` class
- This ensures `ml-auto` on badge spans pushes them to the right edge in both selected and unselected states

Closes #41

## Test plan

- [ ] Verify issue count badge is visible when Issues filter is NOT selected
- [ ] Verify PR count badge is visible when PRs filter is NOT selected
- [ ] Verify badges still display correctly when filters ARE selected
- [ ] Verify notes counter still works as before

🤖 Generated with [Ossue](https://ossue.dev)