### PR TITLE
feat: auto-focus project selector when creating note without project

### DIFF
--- a/src/components/notes/CreateNoteDialog.tsx
+++ b/src/components/notes/CreateNoteDialog.tsx
@@ -43,6 +43,7 @@ export function CreateNoteDialog() {
   const [keepOpen, setKeepOpen] = useState(false);
   const [mode, setMode] = useState<"note" | "issue">("issue");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const selectTriggerRef = useRef<HTMLButtonElement>(null);
 
   const isEditing = !!editingNote;
 
@@ -59,7 +60,17 @@ export function CreateNoteDialog() {
       }
       setIsSaving(false);
       setIsAnalyzing(false);
-      setTimeout(() => textareaRef.current?.focus(), 100);
+      const resolvedProjectId = editingNote
+        ? editingNote.project_id
+        : (defaultProjectId ?? lastUsedProjectId ?? "");
+      setTimeout(() => {
+        if (!resolvedProjectId) {
+          selectTriggerRef.current?.focus();
+          selectTriggerRef.current?.click();
+        } else {
+          textareaRef.current?.focus();
+        }
+      }, 100);
     }
   }, [isCreateNoteOpen, editingNote]);
 
@@ -184,9 +195,15 @@ export function CreateNoteDialog() {
             </span>
             <Select
               value={selectedProjectId}
-              onValueChange={setSelectedProjectId}
+              onValueChange={(value) => {
+                const wasEmpty = !selectedProjectId;
+                setSelectedProjectId(value);
+                if (wasEmpty && value) {
+                  setTimeout(() => textareaRef.current?.focus(), 100);
+                }
+              }}
             >
-              <SelectTrigger className="h-8 text-sm flex-1">
+              <SelectTrigger ref={selectTriggerRef} className="h-8 text-sm flex-1">
                 <SelectValue placeholder="Choose a repository..." />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
## Summary

- When opening the create note dialog without a pre-selected project, automatically focus and open the project selector dropdown
- After selecting a project, focus moves to the textarea for immediate content input
- When a project is already selected (via sidebar filter or last used), textarea gets focus as before

Closes #39

## Test plan

- [ ] Open create note dialog with no project selected (Cmd+N) — project dropdown opens automatically
- [ ] Select a project using keyboard arrows + Enter — focus moves to textarea
- [ ] Open create note dialog with a project pre-selected — textarea gets focus directly
- [ ] Dismiss the dropdown without selecting — dialog remains usable
- [ ] Edit an existing note — textarea gets focus (not project selector)

🤖 Generated with [Ossue](https://ossue.dev)