### PR TITLE
fix: fetch fresh PR diff in send_chat_message to provide context without Analyze

### DIFF
--- a/crates/core/src/services/context.rs
+++ b/crates/core/src/services/context.rs
@@ -295,6 +295,7 @@ impl ContextService {
     ) -> ItemContext {
         let mut comments: Vec<ContextComment> = Vec::new();
         let mut commits: Vec<ContextCommit> = Vec::new();
+        let mut pr_diff: Option<String> = None;
 
         match item_type {
             ItemType::Issue => {
@@ -352,6 +353,38 @@ impl ContextService {
                         "Failed to fetch GitLab MR commits for context"
                     );
                 }
+
+                // MR diff
+                tracing::debug!(
+                    project_id = project_id,
+                    mr_iid = external_id,
+                    "Fetching MR diff"
+                );
+                match client.get_mr_diff(project_id, external_id).await {
+                    Ok(diff) => {
+                        const MAX_DIFF_CHARS: usize = 200_000;
+                        if diff.len() > MAX_DIFF_CHARS {
+                            tracing::warn!(
+                                project_id = project_id,
+                                mr_iid = external_id,
+                                original_len = diff.len(),
+                                "Truncating large MR diff to {} chars",
+                                MAX_DIFF_CHARS
+                            );
+                            pr_diff = Some(diff.chars().take(MAX_DIFF_CHARS).collect());
+                        } else {
+                            pr_diff = Some(diff);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            project_id = project_id,
+                            external_id = external_id,
+                            error = %e,
+                            "Failed to fetch MR diff, continuing without it"
+                        );
+                    }
+                }
             }
             ItemType::Discussion | ItemType::Note => {
                 // GitLab discussions and notes don't have a separate notes endpoint.
@@ -389,7 +422,7 @@ impl ContextService {
             focus_areas: Vec::new(),
             review_strictness: None,
             response_tone: None,
-            pr_diff: None,
+            pr_diff,
         }
     }
 

--- a/crates/core/src/services/gitlab.rs
+++ b/crates/core/src/services/gitlab.rs
@@ -97,6 +97,35 @@ pub struct GitLabCommit {
     pub created_at: String,
 }
 
+#[derive(Deserialize)]
+struct MrChange {
+    old_path: String,
+    new_path: String,
+    diff: String,
+}
+
+#[derive(Deserialize)]
+struct MrChangesResponse {
+    changes: Vec<MrChange>,
+}
+
+/// Parse a GitLab MR changes JSON response into a unified diff string.
+fn parse_mr_changes_to_diff(body: &str) -> std::result::Result<String, serde_json::Error> {
+    let mr_changes: MrChangesResponse = serde_json::from_str(body)?;
+    let mut diff = String::new();
+    for change in &mr_changes.changes {
+        diff.push_str(&format!(
+            "diff --git a/{} b/{}\n",
+            change.old_path, change.new_path
+        ));
+        diff.push_str(&change.diff);
+        if !change.diff.ends_with('\n') {
+            diff.push('\n');
+        }
+    }
+    Ok(diff)
+}
+
 impl GitLabClient {
     pub fn new(token: String, base_url: Option<String>) -> Self {
         let client = reqwest::Client::builder()
@@ -625,6 +654,59 @@ impl GitLabClient {
         );
         Ok(commits)
     }
+    /// Fetch the unified diff for a GitLab merge request.
+    ///
+    /// Uses the `/merge_requests/:iid/changes` endpoint and assembles a unified
+    /// diff string from the individual file diffs returned in the `changes` array.
+    pub async fn get_mr_diff(&self, project_id: i64, mr_iid: i32) -> Result<String> {
+        let project_id_str = project_id.to_string();
+        let mr_iid_str = mr_iid.to_string();
+
+        tracing::debug!(project_id = project_id, mr_iid = mr_iid, "Fetching MR diff");
+
+        let description = format!("GitLab MR diff for project {project_id} MR {mr_iid}");
+        let response = crate::services::http::fetch_with_retry(&description, 3, || {
+            self.client
+                .get(format!(
+                    "{}/api/v4/projects/{project_id_str}/merge_requests/{mr_iid_str}/changes",
+                    self.base_url
+                ))
+                .header("PRIVATE-TOKEN", &self.token)
+                .send()
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, project_id = project_id, mr_iid = mr_iid, "Failed to fetch MR diff");
+            Error::Api(e.to_string())
+        })?;
+
+        let body = response
+            .error_for_status()
+            .inspect_err(|e| {
+                tracing::error!(status = ?e.status(), project_id = project_id, mr_iid = mr_iid, "GitLab API error fetching MR diff");
+            })?
+            .text()
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, project_id = project_id, mr_iid = mr_iid, "Failed to read MR diff response body");
+                e
+            })?;
+
+        let diff = parse_mr_changes_to_diff(&body).map_err(|e| {
+            tracing::error!(error = %e, body_preview = %&body[..body.len().min(200)], project_id = project_id, mr_iid = mr_iid, "Failed to decode MR changes");
+            Error::Decode(e)
+        })?;
+
+        tracing::debug!(
+            project_id = project_id,
+            mr_iid = mr_iid,
+            diff_len = diff.len(),
+            "Fetched GitLab MR diff"
+        );
+
+        Ok(diff)
+    }
+
     pub async fn post_comment(
         &self,
         project_id: i64,
@@ -814,5 +896,96 @@ impl IssueCreator for GitLabClient {
             number: parsed.iid,
             url: parsed.web_url,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mr_changes_single_file() {
+        let json = r#"{
+            "changes": [
+                {
+                    "old_path": "src/main.rs",
+                    "new_path": "src/main.rs",
+                    "diff": "@@ -1,3 +1,4 @@\n fn main() {\n+    println!(\"hello\");\n }\n"
+                }
+            ]
+        }"#;
+
+        let diff = parse_mr_changes_to_diff(json).unwrap();
+        assert!(diff.starts_with("diff --git a/src/main.rs b/src/main.rs\n"));
+        assert!(diff.contains("println!(\"hello\")"));
+    }
+
+    #[test]
+    fn parse_mr_changes_multiple_files() {
+        let json = r#"{
+            "changes": [
+                {
+                    "old_path": "a.rs",
+                    "new_path": "a.rs",
+                    "diff": "+line1\n"
+                },
+                {
+                    "old_path": "b.rs",
+                    "new_path": "b.rs",
+                    "diff": "+line2\n"
+                }
+            ]
+        }"#;
+
+        let diff = parse_mr_changes_to_diff(json).unwrap();
+        assert!(diff.contains("diff --git a/a.rs b/a.rs\n"));
+        assert!(diff.contains("diff --git a/b.rs b/b.rs\n"));
+        assert!(diff.contains("+line1"));
+        assert!(diff.contains("+line2"));
+    }
+
+    #[test]
+    fn parse_mr_changes_empty() {
+        let json = r#"{"changes": []}"#;
+        let diff = parse_mr_changes_to_diff(json).unwrap();
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn parse_mr_changes_appends_trailing_newline_when_missing() {
+        let json = r#"{
+            "changes": [
+                {
+                    "old_path": "file.txt",
+                    "new_path": "file.txt",
+                    "diff": "+no trailing newline"
+                }
+            ]
+        }"#;
+
+        let diff = parse_mr_changes_to_diff(json).unwrap();
+        assert!(diff.ends_with('\n'));
+    }
+
+    #[test]
+    fn parse_mr_changes_renamed_file() {
+        let json = r#"{
+            "changes": [
+                {
+                    "old_path": "old_name.rs",
+                    "new_path": "new_name.rs",
+                    "diff": "@@ -0,0 +0,0 @@\n"
+                }
+            ]
+        }"#;
+
+        let diff = parse_mr_changes_to_diff(json).unwrap();
+        assert!(diff.contains("diff --git a/old_name.rs b/new_name.rs\n"));
+    }
+
+    #[test]
+    fn parse_mr_changes_invalid_json() {
+        let result = parse_mr_changes_to_diff("not json");
+        assert!(result.is_err());
     }
 }

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -195,6 +195,7 @@ impl AnalysisContext {
         }
 
         // Use fresh diff if provided, otherwise fall back to DB-cached diff
+        #[allow(clippy::unnecessary_lazy_evaluations)]
         let diff_to_use = fresh_diff.or_else(|| {
             if let ossue_core::enums::ItemTypeData::Pr(ref pr) = td {
                 pr.pr_diff.as_deref()
@@ -370,9 +371,11 @@ pub async fn send_chat_message(
 
     tracing::debug!(item_id = %item_id, message_count = api_messages.len(), ai_mode = %ctx.ai_mode, "Conversation history prepared");
 
-    // Fetch fresh PR diff from GitHub API (same pattern as auto_analyze_item)
+    // Parse type data once for diff fetching and worktree setup
+    let td = ctx.item.parse_type_data().ok();
+
+    // Fetch fresh PR/MR diff from platform API
     let fresh_diff = if ctx.item.item_type == ossue_core::enums::ItemType::PullRequest {
-        let td = ctx.item.parse_type_data().ok();
         let cached_diff = match &td {
             Some(ossue_core::enums::ItemTypeData::Pr(pr)) => pr.pr_diff.clone(),
             _ => None,
@@ -389,21 +392,30 @@ pub async fn send_chat_message(
                         .get_pr_diff(&ctx.project.owner, &ctx.project.name, ext_id)
                         .await
                     {
-                        Ok(diff) => {
-                            let truncated = if diff.len() > 200_000 {
-                                diff[..200_000].to_string()
-                            } else {
-                                diff
-                            };
-                            Some(truncated)
-                        }
+                        Ok(diff) => Some(truncate_diff(diff)),
                         Err(e) => {
                             tracing::warn!(error = %e, item_id = %item_id, "Failed to fetch fresh PR diff for chat, falling back to cached");
                             cached_diff
                         }
                     }
                 }
-                ossue_core::enums::Platform::GitLab => cached_diff,
+                ossue_core::enums::Platform::GitLab => {
+                    if let Some(project_id) = ctx.project.external_project_id {
+                        let client = ossue_core::services::gitlab::GitLabClient::new(
+                            ctx.token.clone(),
+                            ctx.github_base_url.clone(),
+                        );
+                        match client.get_mr_diff(project_id, ext_id).await {
+                            Ok(diff) => Some(truncate_diff(diff)),
+                            Err(e) => {
+                                tracing::warn!(error = %e, item_id = %item_id, "Failed to fetch fresh MR diff for chat, falling back to cached");
+                                cached_diff
+                            }
+                        }
+                    } else {
+                        cached_diff
+                    }
+                }
             }
         } else {
             cached_diff
@@ -418,7 +430,6 @@ pub async fn send_chat_message(
     system_prompt.push_str(&ctx.build_item_context_block(fresh_diff.as_deref()));
 
     // Determine PR number and default branch for correct worktree checkout
-    let td = ctx.item.parse_type_data().ok();
     let pr_number = if ctx.item.item_type == ossue_core::enums::ItemType::PullRequest {
         td.as_ref().and_then(|t| t.external_id())
     } else {
@@ -688,14 +699,7 @@ pub async fn auto_analyze_item(
                         .get_pr_diff(&project.owner, &project.name, ext_id)
                         .await
                     {
-                        Ok(diff) => {
-                            let truncated = if diff.len() > 200_000 {
-                                diff[..200_000].to_string()
-                            } else {
-                                diff
-                            };
-                            Some(truncated)
-                        }
+                        Ok(diff) => Some(truncate_diff(diff)),
                         Err(e) => {
                             tracing::warn!(error = %e, item_id = %item_id, "Failed to fetch fresh PR diff, falling back to cached");
                             cached_diff
@@ -703,8 +707,21 @@ pub async fn auto_analyze_item(
                     }
                 }
                 Platform::GitLab => {
-                    // GitLab doesn't have a diff endpoint; use cached if available
-                    cached_diff
+                    if let Some(project_id) = project.external_project_id {
+                        let client = ossue_core::services::gitlab::GitLabClient::new(
+                            token.clone(),
+                            github_base_url.clone(),
+                        );
+                        match client.get_mr_diff(project_id, ext_id).await {
+                            Ok(diff) => Some(truncate_diff(diff)),
+                            Err(e) => {
+                                tracing::warn!(error = %e, item_id = %item_id, "Failed to fetch fresh MR diff, falling back to cached");
+                                cached_diff
+                            }
+                        }
+                    } else {
+                        cached_diff
+                    }
                 }
             }
         } else {
@@ -1694,6 +1711,16 @@ const MAX_CHAT_MESSAGES: usize = 30;
 /// Keeps the first message (original analysis prompt) and the most recent
 /// messages within the character and message count budgets.
 /// Preserves user/assistant alternation.
+/// Truncate a diff string to at most `MAX_DIFF_CHARS` characters, safely
+/// handling multi-byte UTF-8 boundaries.
+const MAX_DIFF_CHARS: usize = 200_000;
+fn truncate_diff(diff: String) -> String {
+    if diff.len() <= MAX_DIFF_CHARS {
+        return diff;
+    }
+    diff.chars().take(MAX_DIFF_CHARS).collect()
+}
+
 fn truncate_chat_history(messages: Vec<ApiMessage>) -> Vec<ApiMessage> {
     if messages.len() <= MAX_CHAT_MESSAGES {
         let total_chars: usize = messages.iter().map(|m| m.content.len()).sum();


### PR DESCRIPTION
Closes #60

  - Fetch fresh PR diff from the GitHub API in `send_chat_message` so the LLM
    has full context even when "Analyze" was never clicked
  - Extract common context-gathering logic into `AnalysisContext` struct shared
    by `send_chat_message` and `analyze_item_action`
  - `build_item_context_block` accepts an optional fresh diff, falling back to
    the DB-cached diff when unavailable